### PR TITLE
Convert Makefile to use standard Kernel CROSS_COMPILE shell variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CC=arm-none-eabi-gcc
-LD=arm-none-eabi-ld.bfd
-OBJCOPY=arm-none-eabi-objcopy
+CC=$(CROSS_COMPILE)gcc
+LD=$(CROSS_COMPILE)ld.bfd
+OBJCOPY=$(CROSS_COMPILE)objcopy
 
 all: bootblk.bin
 


### PR DESCRIPTION
Hi, I've made a minor change to the Makefile so that it uses the same variable as u-boot / Linux Kernel use for cross compiling.

This change also means that it works on native ARM.
